### PR TITLE
Prepare CI/CD Workflows

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -68,9 +68,11 @@ jobs:
         working-directory: otterdog-configs
 
       - name: Validate Otterdog Configuration and diff HEAD <-> BASE
+        id: validate
         run: |
           # use script to enable ansi color output
-          script -q /dev/null --command "../otterdog/otterdog.sh local-plan ${{ github.repository_owner }} -c otterdog.json --suffix=-BASE" | tee "$GITHUB_WORKSPACE/diff-ansi.txt"
+          script -e -q /dev/null --command "../otterdog/otterdog.sh local-plan ${{ github.repository_owner }} -c otterdog.json --suffix=-BASE" | tee "$GITHUB_WORKSPACE/diff-ansi.txt"
+          echo "VALIDATION_STATUS=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT
           # filter out ansi escape sequences again, use sed as ansi2txt is not available
           cat "$GITHUB_WORKSPACE/diff-ansi.txt" | sed -e 's/\x1b\[[0-9;]*m//g' | sed -E 's/^([[:space:]]+)([-+!])/\2\1/g' | sed -E 's/^([[:space:]]+)([~])/!\1/g' > "$GITHUB_WORKSPACE/diff.txt"
         working-directory: otterdog-configs
@@ -104,3 +106,7 @@ jobs:
           hide_and_recreate: true
           hide_classify: "OUTDATED"
           path: ${{ github.workspace }}/comment.txt
+
+      - name: Propagate validation exit status
+        run: |
+          exit ${{ steps.validate.outputs.VALIDATION_STATUS }}

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -40,13 +40,14 @@ orgs.newOrg('eclipse-opendut') {
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 1,
           required_status_checks: [
+            "eclipse-eca-validation:eclipsefdn/eca",
             "build",
           ],
           requires_conversation_resolution: true,
         },
         orgs.newBranchProtectionRule('development') {
           allows_force_pushes: true,
-          required_approving_review_count: 0,
+          required_approving_review_count: null,
           requires_pull_request: false,
         },
       ],

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -24,6 +24,14 @@ orgs.newOrg('eclipse-opendut') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
+      variables+: [
+        orgs.newRepoVariable('OPENDUT_GH_RUNNER_SMALL') {
+          value: '["ubuntu-latest"]',
+        },
+        orgs.newRepoVariable('OPENDUT_GH_RUNNER_LARGE') {
+          value: '["ubuntu-latest"]',
+        },
+      ],
       topics+: [
         "automotive",
       ],

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -39,8 +39,7 @@ orgs.newOrg('eclipse-opendut') {
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 1,
-          required_status_checks: [
-            "eclipse-eca-validation:eclipsefdn/eca",
+          required_status_checks+: [
             "build",
           ],
           requires_conversation_resolution: true,

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -30,7 +30,7 @@ orgs.newOrg('eclipse-opendut') {
           value: '["ubuntu-latest"]',
         },
         orgs.newRepoVariable('OPENDUT_RUN_TESTENV') {
-          value: false,
+          value: "false",
         },
       ],
       topics+: [

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -44,6 +44,11 @@ orgs.newOrg('eclipse-opendut') {
           ],
           requires_conversation_resolution: true,
         },
+        orgs.newBranchProtectionRule('development') {
+          allows_force_pushes: true,
+          required_approving_review_count: 0,
+          requires_pull_request: false,
+        },
       ],
       web_commit_signoff_required: false,
       workflows+: {

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -21,8 +21,6 @@ orgs.newOrg('eclipse-opendut') {
       has_projects: true,
       has_discussions: true,
       has_wiki: false,
-      allow_merge_commit: true,
-      allow_update_branch: false,
       delete_branch_on_merge: false,
       variables+: [
         orgs.newRepoVariable('OPENDUT_GH_RUNNER_SMALL') {
@@ -51,8 +49,6 @@ orgs.newOrg('eclipse-opendut') {
       },
     },
     orgs.newRepo('.github') {
-      allow_merge_commit: true,
-      allow_update_branch: false,
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
       workflows+: {

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -31,6 +31,9 @@ orgs.newOrg('eclipse-opendut') {
         orgs.newRepoVariable('OPENDUT_GH_RUNNER_LARGE') {
           value: '["ubuntu-latest"]',
         },
+        orgs.newRepoVariable('OPENDUT_RUN_TESTENV') {
+          value: false,
+        },
       ],
       topics+: [
         "automotive",

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -5,7 +5,7 @@ orgs.newOrg('eclipse-opendut') {
     dependabot_security_updates_enabled_for_new_repositories: false,
     description: "Test Electronic Control Units around the world in a transparent network.",
     members_can_change_project_visibility: false,
-    name: "Eclipse Opendut Project",
+    name: "Eclipse openDuT",
     packages_containers_internal: false,
     packages_containers_public: false,
     readers_can_create_discussions: true,

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -39,8 +39,10 @@ orgs.newOrg('eclipse-opendut') {
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 1,
+          required_status_checks: [
+            "build",
+          ],
           requires_conversation_resolution: true,
-          requires_status_checks: false,
         },
       ],
       web_commit_signoff_required: false,


### PR DESCRIPTION
Hello,
we're preparing our CI/CD contributions and want to use a few variables to control that.

Additionally, we've changed the `development` branch to not be deleteable. We want to use it long-term as a basin for stabilizing before merging onto `main`.

And I've changed the spelling for the Org name. We seem to have standardized on that specific casing.