### PR TITLE
Rename status-check job to 'status-check'.

### DIFF
--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -38,7 +38,7 @@ orgs.newOrg('eclipse-opendut') {
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 1,
           required_status_checks+: [
-            "build",
+            "status-check",
           ],
           requires_conversation_resolution: true,
         },


### PR DESCRIPTION
Hi,
we realized all jobs would have to be specified individually, if we want to use multiple for status checks.

Instead, we want to use a single job at the end of our build workflow, which depends on all jobs that we want completed.  
For this purpose, we'd like to change the name of this job.