### PR TITLE
Create repository to publish GitHub Page

### DIFF
--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -76,14 +76,14 @@ orgs.newOrg('eclipse-opendut') {
       workflows+: {
         actions_can_approve_pull_request_reviews: false,
       },
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "main"
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
     },
-    environments: [
-      orgs.newEnvironment('github-pages') {
-        branch_policies+: [
-          "main"
-        ],
-        deployment_branch_policy: "selected",
-      },
-    ],
   ],
 }

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -67,5 +67,23 @@ orgs.newOrg('eclipse-opendut') {
         actions_can_approve_pull_request_reviews: false,
       },
     },
+    orgs.newRepo('eclipse-opendut.github.io') {
+      delete_branch_on_merge: false,
+      web_commit_signoff_required: false,
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "main",
+      gh_pages_source_path: "/",
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
+    },
+    environments: [
+      orgs.newEnvironment('github-pages') {
+        branch_policies+: [
+          "main"
+        ],
+        deployment_branch_policy: "selected",
+      },
+    ],
   ],
 }


### PR DESCRIPTION
We would like to provide a landing page for OpenDuT. Interested parties shall see what the project is about and may click a link to the documentation. My understanding is that we can push the actual page to the repository created with this pull request. If there is anything else to do, please let us know :-)