### PR TITLE
Link homepage

### DIFF
--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -15,6 +15,7 @@ orgs.newOrg('eclipse-opendut') {
   _repositories+:: [
     orgs.newRepo('opendut') {
       description: "Test Electronic Control Units around the world in a transparent network.",
+      homepage: "https://opendut.eclipse.dev/",
       has_discussions: true,
       has_wiki: false,
       delete_branch_on_merge: false,


### PR DESCRIPTION
Hi,
we have a new landing page for openDuT at https://opendut.eclipse.dev/ (still work-in-progress) and would like to link that in the repository.