### PR TITLE
Changes to release GitHub Pages by branch 

### DIFF
--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -38,6 +38,9 @@ orgs.newOrg('eclipse-opendut') {
       has_discussions: true,
       has_wiki: false,
       homepage: "https://opendut.eclipse.dev/",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "github-pages",
+      gh_pages_source_path: "/",
       topics+: [
         "automotive"
       ],
@@ -73,6 +76,14 @@ orgs.newOrg('eclipse-opendut') {
           requires_commit_signatures: false,
           requires_pull_request: false,
           requires_status_checks: false,
+        },
+      ],
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "github-pages"
+          ],
+          deployment_branch_policy: "selected",
         },
       ],
     },

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -81,8 +81,7 @@ orgs.newOrg('eclipse-opendut') {
             "main",
             "development",
              "v[0-9].[0-9].[0-9]",
-             "v[0-9].[0-9].[0-9]-*",
-             "canary"
+             "v[0-9].[0-9].[0-9]-*"
           ],
           deployment_branch_policy: "selected",
         },

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -37,9 +37,7 @@ orgs.newOrg('eclipse-opendut') {
       has_discussions: true,
       has_wiki: false,
       homepage: "https://opendut.eclipse.dev/",
-      gh_pages_build_type: "legacy",
-      gh_pages_source_branch: "github-pages",
-      gh_pages_source_path: "/",
+      gh_pages_build_type: "workflow",
       topics+: [
         "automotive"
       ],
@@ -80,7 +78,11 @@ orgs.newOrg('eclipse-opendut') {
       environments: [
         orgs.newEnvironment('github-pages') {
           branch_policies+: [
-            "github-pages"
+            "main",
+            "development",
+             "v[0-9].[0-9].[0-9]",
+             "v[0-9].[0-9].[0-9]-*",
+             "canary"
           ],
           deployment_branch_policy: "selected",
         },


### PR DESCRIPTION
Hi,

together with @mbfm we worked on another approach of getting our GitHub Pages build and released.

Our intention is to switch from a dedicated repository, which is `eclipse-opendut.github.io`, to a branch-based build and release process.
This changes were necessary since we want to integrate the building process into our Pipeline, which gets triggered in certain situation, i.e. a push to main or development branch.

For this to happen we extended our .jsonnet file:
  - adding three properties to repository `opendut`:

  - adding new environment to repository `opendut`
  
  - still kept the repository `eclipse-opendut.github.io` where it was, since we want to make a redirect to the new URL. Contents there will be removed, but a redirect will be added later.
  	
 
 I'm looking forward to hear your opinion and/or questions on our changes.
 
 Kind regards,
 Matthias Twardawski (Mercedes-Benz Tech Innovation) 
