### PR TITLE
Remove eclipse-opendut.github.io repository.

### DIFF
--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -16,21 +16,6 @@ orgs.newOrg('eclipse-opendut') {
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
     },
-    orgs.newRepo('eclipse-opendut.github.io') {
-      delete_branch_on_merge: false,
-      gh_pages_build_type: "legacy",
-      gh_pages_source_branch: "main",
-      gh_pages_source_path: "/",
-      web_commit_signoff_required: false,
-      environments: [
-        orgs.newEnvironment('github-pages') {
-          branch_policies+: [
-            "main"
-          ],
-          deployment_branch_policy: "selected",
-        },
-      ],
-    },
     orgs.newRepo('opendut') {
       delete_branch_on_merge: false,
       description: "Test Electronic Control Units around the world in a transparent network.",


### PR DESCRIPTION
Since we're now using a GitHub Action to publish the webpage, the separate GitHub Pages repository can be removed.

As discussed here: https://github.com/eclipse-opendut/.eclipsefdn/pull/9
And confirmed once more here: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4588