### PR TITLE
Add repository for release builds of cannelloni.

### DIFF
--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -21,7 +21,7 @@ orgs.newOrg('eclipse-opendut') {
       description: "Test Electronic Control Units around the world in a transparent network.",
       has_discussions: true,
       has_wiki: false,
-      homepage: "https://opendut.eclipse.dev/",
+      homepage: "https://opendut.eclipse.dev",
       gh_pages_build_type: "workflow",
       topics+: [
         "automotive"
@@ -71,6 +71,13 @@ orgs.newOrg('eclipse-opendut') {
           deployment_branch_policy: "selected",
         },
       ],
+    },
+    orgs.newRepo('cannelloni') {
+      delete_branch_on_merge: false,
+      web_commit_signoff_required: false,
+      description: "Build cannelloni for multiple architectures.",
+      has_wiki: false,
+      homepage: "https://github.com/mguentner/cannelloni",
     },
   ],
 }


### PR DESCRIPTION
We would like to create release builds of [cannelloni](https://github.com/mguentner/cannelloni), to make use of them in openDuT.

We want to place the CI/CD code into a separate repository and also make the releases available there.