### PR TITLE
Rename cannelloni-repo to 'cannelloni-build' to avoid confusion.

### DIFF
--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -71,6 +71,7 @@ orgs.newOrg('eclipse-opendut') {
       ],
     },
     orgs.newRepo('cannelloni') {
+      name: "cannelloni-build",
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
       description: "Build cannelloni for multiple architectures.",

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -70,8 +70,8 @@ orgs.newOrg('eclipse-opendut') {
         },
       ],
     },
-    orgs.newRepo('cannelloni') {
-      name: "cannelloni-build",
+    orgs.newRepo('cannelloni-build') {
+      aliases: ["cannelloni"],
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
       description: "Build cannelloni for multiple architectures.",


### PR DESCRIPTION
We've received feedback that the name 'cannelloni' may lead people to believe that this is the official Cannelloni project.
Therefore, we'd like to rename the repository. I'm guessing that setting the name-field would do this.