### PR TITLE
Add repositories for providing builds of rperf and NetBird.

### DIFF
--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -78,6 +78,22 @@ orgs.newOrg('eclipse-opendut') {
       has_wiki: false,
       homepage: "https://github.com/mguentner/cannelloni",
     },
+    orgs.newRepo('netbird-fork') {
+      delete_branch_on_merge: false,
+      web_commit_signoff_required: false,
+      description: "Netbird with adjustments for openDuT.",
+      forked_repository: "https://github.com/netbirdio/netbird",
+      fork_default_branch_only: true,
+      has_wiki: false,
+      homepage: "https://netbird.io",
+    },
+    orgs.newRepo('netbird-build') {
+      delete_branch_on_merge: false,
+      web_commit_signoff_required: false,
+      description: "Build Netbird for multiple architectures.",
+      has_wiki: false,
+      homepage: "https://netbird.io",
+    },
     orgs.newRepo('rperf-build') {
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -78,5 +78,12 @@ orgs.newOrg('eclipse-opendut') {
       has_wiki: false,
       homepage: "https://github.com/mguentner/cannelloni",
     },
+    orgs.newRepo('rperf-build') {
+      delete_branch_on_merge: false,
+      web_commit_signoff_required: false,
+      description: "Build rperf for multiple architectures.",
+      has_wiki: false,
+      homepage: "https://github.com/opensource-3d-p/rperf",
+    },
   ],
 }


### PR DESCRIPTION
We would like to provide builds of [`rperf`](https://github.com/opensource-3d-p/rperf) and [NetBird](https://netbird.io) akin to `cannelloni` in a separate repository, to avoid any licensing issues that might arise from compiling it within the `opendut` repository.