### PR TITLE
Adjust environment deployment policies for tags

### DIFF
--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -63,6 +63,8 @@ orgs.newOrg('eclipse-opendut') {
           branch_policies+: [
             "main",
             "development",
+            "tag:v[0-9].[0-9].[0-9]",
+            "tag:v[0-9].[0-9].[0-9]-*",
           ],
           deployment_branch_policy: "selected",
         },

--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -63,8 +63,6 @@ orgs.newOrg('eclipse-opendut') {
           branch_policies+: [
             "main",
             "development",
-             "v[0-9].[0-9].[0-9]",
-             "v[0-9].[0-9].[0-9]-*"
           ],
           deployment_branch_policy: "selected",
         },


### PR DESCRIPTION
Publishing from a tag still fails: https://github.com/eclipse-opendut/opendut/actions/runs/10794036097

And we don't necessarily need to publish from tags, as we publish the documentation with each push to `development` and `main` anyways.