### PR TITLE
Add repository for `raspberry-pi-wireless-bootstrap`

### DIFF
--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -67,6 +67,15 @@ orgs.newOrg('automotive.opendut', 'eclipse-opendut') {
         },
       ],
     },
+    orgs.newRepo('raspberry-pi-wireless-bootstrap') {
+      delete_branch_on_merge: false,
+      description: "Easily configure your Raspberry Pi from scratch via WiFi hotspot.",
+      has_wiki: false,
+      topics+: [
+        "raspberry-pi"
+      ],
+      web_commit_signoff_required: false,
+    },
     orgs.newRepo('cannelloni-build') {
       aliases: ["cannelloni"],
       delete_branch_on_merge: false,


### PR DESCRIPTION
We've been working on a way to easily set up a Raspberry Pi from scratch and realized that it is useful independently from openDuT. To make it more visible and allow for separate releases, we want to put it into a separate repository.