### PR TITLE
Enable discussions in `eclipse-opendut` organisation

### DIFF
--- a/otterdog/eclipse-opendut.jsonnet
+++ b/otterdog/eclipse-opendut.jsonnet
@@ -2,8 +2,10 @@ local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 
 orgs.newOrg('automotive.opendut', 'eclipse-opendut') {
   settings+: {
-    description: "Test Electronic Control Units around the world in a transparent network.",
     name: "Eclipse openDuT",
+    description: "Test Electronic Control Units around the world in a transparent network.",
+    discussion_source_repository: "eclipse-opendut/opendut",
+    has_discussions: true,
     web_commit_signoff_required: false,
     workflows+: {
       actions_can_approve_pull_request_reviews: false,


### PR DESCRIPTION
We'd like to start using GitHub Discussions for our meeting minutes, akin to how S-CORE does it: https://github.com/orgs/eclipse-score/discussions  
As such, we would like the Discussions to be easily accessible in our [organization overview](https://github.com/eclipse-opendut).

From what I understand, it is possible to link the Discussions from one repository into the whole organization, which is what we would like to do with this pull request.  
In particular, we want to link it from our [monorepo](https://github.com/eclipse-opendut/opendut/discussions).

I've adapted the changes from the configuration that S-CORE uses, which can be found here: https://github.com/eclipse-score/.eclipsefdn/blob/9b66b56cd6b4c8201cdefab2e194031e112bcce6/otterdog/eclipse-score.jsonnet#L80-L81